### PR TITLE
ngdocs: Factory placeholder

### DIFF
--- a/generators/app/templates/app/app.module.js
+++ b/generators/app/templates/app/app.module.js
@@ -79,3 +79,14 @@ angular
   *
   * All the services of the apps belong to this package.
 **/
+
+/**
+  * @ngdoc object
+  * @name app.filters
+  * @module app
+  * @description
+  *
+  * It is a logic container.
+  *
+  * All the filters of the apps belong to this package.
+**/


### PR DESCRIPTION
Add the a factory placeholder within the app.modules.js, as already done for modules, directives and services.